### PR TITLE
Some issues on Windows when php commands were run.

### DIFF
--- a/phpparser.py
+++ b/phpparser.py
@@ -434,9 +434,11 @@ def PHPopen(php):
     '''
     Runs php through the application without showing a console window
     '''
-    startupinfo = subprocess.STARTUPINFO()
-    startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-    startupinfo.wShowWindow = subprocess.SW_HIDE
+    startupinfo = None
+    if os.name == 'nt':
+        startupinfo = subprocess.STARTUPINFO()
+        startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+        startupinfo.wShowWindow = subprocess.SW_HIDE
     return subprocess.Popen(['php', '-r', php], bufsize=1, startupinfo=startupinfo, stdout=subprocess.PIPE, shell=False).communicate()[0]
     
 


### PR DESCRIPTION
In Windows 8 with ST3 each time a file was passed through PHP to retrieve tokens. It would steal focus and generally interfere with normal usage on initial open and after saves. 

I have added `startupinfo` to the `subprocess.Popen` call with settings to hide any resulting windows and avoid activation.

Also I refactored this into its own function now that it is providing an explicit behavior beyond Popen.
